### PR TITLE
fix: deprecated error

### DIFF
--- a/layouts/partials/mod-img/helper/debug.html
+++ b/layouts/partials/mod-img/helper/debug.html
@@ -1,4 +1,4 @@
-{{- if and site.IsServer site.Data.modImg.debug }}
+{{- if and hugo.IsServer site.Data.modImg.debug }}
 <span>
     <pre style="max-width: 40rem; margin: 0 auto; font-size: 10px; line-height: 1.2; background-color: #ddd; overflow-x: auto">
     {{- print (transform.Remarshal "toml" . ) -}}


### PR DESCRIPTION
Use `hugo.IsServer` instead of `site.IsServer` (deprecated in Hugo v0.120.0).